### PR TITLE
[user-service] No need to define OomScore. Max value is inherited from systemd

### DIFF
--- a/rpm/dbus-user.service
+++ b/rpm/dbus-user.service
@@ -10,4 +10,4 @@ Requires=dbus.socket
 [Service]
 ExecStart=/bin/dbus-daemon --session --address=systemd: --nofork --systemd-activation
 ExecReload=/bin/dbus-send --print-reply --session --type=method_call --dest=org.freedesktop.DBus / org.freedesktop.DBus.ReloadConfig
-OOMScoreAdjust=-850
+


### PR DESCRIPTION
This original OomScore -850 was causing problems with new systemd because any user session can't set Oom value "bigger" than what parent has. This case the parent is user session systemd and it has Oom value -750. Old systemd ignored this error but new one refuses to boot up with incorrect value.
It is better not to define Oom value at all because then we will always inherit the maximum value from systemd.

Signed-off-by: Pekka Lundstrom pekka.lundstrom@jollamobile.com
