### PR TITLE
[init] dbus.service is started as early as possible in basic.target

### DIFF
--- a/dbus/bus/Makefile.am
+++ b/dbus/bus/Makefile.am
@@ -226,8 +226,8 @@ if HAVE_SYSTEMD
 # Unconditionally enable D-Bus on systemd installations
 	$(mkinstalldirs) $(DESTDIR)$(systemdsystemunitdir)/sockets.target.wants
 	ln -fs ../dbus.socket $(DESTDIR)$(systemdsystemunitdir)/sockets.target.wants/dbus.socket
-	$(mkinstalldirs) $(DESTDIR)$(systemdsystemunitdir)/multi-user.target.wants
-	ln -fs ../dbus.service $(DESTDIR)$(systemdsystemunitdir)/multi-user.target.wants/dbus.service
+	$(mkinstalldirs) $(DESTDIR)$(systemdsystemunitdir)/basic.target.wants
+	ln -fs ../dbus.service $(DESTDIR)$(systemdsystemunitdir)/basic.target.wants/dbus.service
 endif
 
 if DBUS_UNIX

--- a/dbus/bus/dbus.service.in
+++ b/dbus/bus/dbus.service.in
@@ -1,10 +1,16 @@
 [Unit]
 Description=D-Bus System Message Bus
 Requires=dbus.socket
-After=syslog.target
+DefaultDependencies=no
+After=local-fs.target dbus.socket
+Before=basic.target
+Conflicts=shutdown.target
 
 [Service]
 ExecStartPre=@EXPANDED_BINDIR@/dbus-uuidgen --ensure
 ExecStart=@EXPANDED_BINDIR@/dbus-daemon --system --address=systemd: --nofork --nopidfile --systemd-activation
 ExecReload=@EXPANDED_BINDIR@/dbus-send --print-reply --system --type=method_call --dest=org.freedesktop.DBus / org.freedesktop.DBus.ReloadConfig
 OOMScoreAdjust=-900
+
+[Install]
+WantedBy=basic.target

--- a/rpm/dbus.spec
+++ b/rpm/dbus.spec
@@ -153,7 +153,7 @@ systemctl daemon-reload
 /lib/systemd/system/dbus.service
 /lib/systemd/system/dbus.socket
 /lib/systemd/system/dbus.target.wants/dbus.socket
-/lib/systemd/system/multi-user.target.wants/dbus.service
+/lib/systemd/system/basic.target.wants/dbus.service
 /lib/systemd/system/sockets.target.wants/dbus.socket
 %attr(4750,root,dbus) /%{_lib}/dbus-1/dbus-daemon-launch-helper
 %dir %{_datadir}/dbus-1


### PR DESCRIPTION
We have multiple services that misbehave during shutdown if dbus daemon exits before them. Because daemons are stopped in reverse order, this early start makes dbus to be stopped as late as possible.

Even we will add explicit requirement also to those misbehaving daemons this change is good anyhow. Makes device more robust for future changes. This also makes device to boot little faster.

Signed-off-by: Pekka Lundstrom pekka.lundstrom@jollamobile.com
