### PR TITLE
[init] Do not allow manual stop for dbus daemon

### DIFF
--- a/dbus/bus/dbus.service.in
+++ b/dbus/bus/dbus.service.in
@@ -5,6 +5,7 @@ DefaultDependencies=no
 After=local-fs.target dbus.socket
 Before=basic.target
 Conflicts=shutdown.target
+RefuseManualStop=yes
 
 [Service]
 ExecStartPre=@EXPANDED_BINDIR@/dbus-uuidgen --ensure

--- a/rpm/dbus-user.service
+++ b/rpm/dbus-user.service
@@ -1,4 +1,3 @@
-
 #
 # This is the D-Bus service for the session
 #
@@ -6,6 +5,7 @@
 [Unit]
 Description=D-Bus Session Message Bus
 Requires=dbus.socket
+RefuseManualStop=yes
 
 [Service]
 ExecStart=/bin/dbus-daemon --session --address=systemd: --nofork --systemd-activation


### PR DESCRIPTION
As we do reboot (by dsme) if dbus daemon does exit, we should prevent accidents to happen by refusing manual stop for dbus.

Signed-off-by: Pekka Lundstrom pekka.lundstrom@jollamobile.com
