### PR TITLE
[packaging] Fix systemd detection in configure. Fixes JB#32512

### DIFF
--- a/rpm/dbus-1.9.0-enable-build-support-without-systemd-compatibility-l.patch
+++ b/rpm/dbus-1.9.0-enable-build-support-without-systemd-compatibility-l.patch
@@ -1,0 +1,46 @@
+This patch is based on upstream commit
+ae268a2b1aaa14e16ffc47b3cd5ad74a26e39838 and fixes JB#32512.
+
+From ae268a2b1aaa14e16ffc47b3cd5ad74a26e39838 Mon Sep 17 00:00:00 2001
+From: Umut Tezduyar Lindskog <umut@tezduyar.com>
+Date: Tue, 2 Sep 2014 09:02:31 +0200
+Subject: [PATCH] enable build support without systemd compatibility libraries
+
+systemd 209 merged all the libraries to libsystemd. Old
+libraries can still be enabled with --enable-compat-libs
+switch in systemd but this increases the binary size.
+
+Implement a fallback library check in case compat libraries
+dont exist.
+
+[Fixed underquoting; switched priority so we try libsystemd first -smcv]
+Signed-off-by: Simon McVittie <simon.mcvittie@collabora.co.uk>
+---
+ configure.ac | 11 +++++++----
+ 1 file changed, 7 insertions(+), 4 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 5412db2..b7b91be 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1169,10 +1169,13 @@ dnl systemd detection
+ if test x$enable_systemd = xno ; then
+     have_systemd=no;
+ else
+-    PKG_CHECK_MODULES(SYSTEMD,
+-        [libsystemd-login >= 32, libsystemd-daemon >= 32],
+-        have_systemd=yes,
+-        have_systemd=no)
++    PKG_CHECK_MODULES([SYSTEMD],
++        [libsystemd >= 209],
++        [have_systemd=yes],
++        [PKG_CHECK_MODULES([SYSTEMD],
++            [libsystemd-login >= 32, libsystemd-daemon >= 32, libsystemd-journal >= 32],
++            [have_systemd=yes],
++            [have_systemd=no])])
+ fi
+ 
+ if test x$have_systemd = xyes; then
+-- 
+2.1.4
+

--- a/rpm/dbus.spec
+++ b/rpm/dbus.spec
@@ -14,6 +14,7 @@ URL:        http://www.freedesktop.org/software/dbus/
 Source0:    http://dbus.freedesktop.org/releases/%{name}/%{name}-%{version}.tar.gz
 Source1:    dbus-user.socket
 Source2:    dbus-user.service
+Patch0:     dbus-1.9.0-enable-build-support-without-systemd-compatibility-l.patch
 Requires:   %{name}-libs = %{version}
 Requires:   systemd
 Requires(pre): /usr/sbin/useradd
@@ -68,6 +69,7 @@ Headers and static libraries for D-Bus.
 
 %prep
 %setup -q -n %{name}-%{version}/dbus
+%patch0 -p1
 
 %build
 


### PR DESCRIPTION
D-Bus' configure.ac when checking for systemd availability looks at
libsystemd-login and libsystemd-daemon shared libraries while in
newer versions of systemd all of these libraries are merged to single
libsystemd.

Backported upstream ae268a2b1aaa14e16ffc47b3cd5ad74a26e39838.

Signed-off-by: Igor Zhbanov igor.zhbanov@jolla.com
